### PR TITLE
fix multiline descriptions

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -17,7 +17,13 @@ dynamic = ["version"]
 {% else %}
 version = "0.1.0"
 {% endif %}
-description = "{{ package_description }}"
+description = {% if "\n" in package_description -%}
+"""\
+{{ package_description }}\
+"""
+{%- else -%}
+"{{ package_description }}"
+{%- endif %}
 authors = [
     { name = "{{ author_name }}", email = "{{ author_email }}" },
 ]


### PR DESCRIPTION
Few students had issues this morning with multiline descriptions, maybe from accidentally hitting enter when writing it?

Anyway this does what it seems like it does, uses triple quotes with multiline strings and single quotes with single line strings. the extra backslashes just strip the leading and trailing whitespace.

So with a multiline description

<img width="480" alt="Screenshot 2024-10-30 at 11 40 12 AM" src="https://github.com/user-attachments/assets/910bb52f-2c5e-4a66-a2cf-273f5444dbe3">

we get this

```toml
[project]
name = "my_project"

version = "0.1.0"

description = """\
sup description

anotherline

third\
"""
authors = [
    { name = "me", email = "me" },
]
```

which parses like

```python
>>> with open('pyproject.toml', 'rb') as tfile:
>>>     project = tomllib.load(tfile)
>>>
>>> data['project']['description']
'sup description\n\nanotherline\n\nthird'
```

And for a single line description we get, as expected

```toml
[project]
name = "my_project"

version = "0.1.0"

description = "description single line"
authors = [
    { name = "me", email = "me" },
]
```