### PR TITLE
fix whitespace in project table

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -12,11 +12,11 @@ requires = ["hatchling"{% if use_vcs_version %}, "hatch-vcs"{% endif %}]
 
 [project]
 name = "{{ package_name }}"
-{% if use_vcs_version %}
+{%- if use_vcs_version %}
 dynamic = ["version"]
 {% else %}
 version = "0.1.0"
-{% endif %}
+{% endif -%}
 description = "{{ package_description }}"
 authors = [
     { name = "{{ author_name }}", email = "{{ author_email }}" },


### PR DESCRIPTION
super minor, just turning this:

```toml
[project]
name = "my_project"

version = "0.1.0"

description = "hey"
```

into this

```toml
[project]
name = "my_project"
version = "0.1.0"
description = "hey"
```

or this

```toml
[project]
name = "mine"
dynamic = ["version"]
description = "hey"
```