### PR TITLE
Add optional deps if not using hatch

### DIFF
--- a/includes/pyproject/deps-pep-621.toml.jinja
+++ b/includes/pyproject/deps-pep-621.toml.jinja
@@ -4,7 +4,7 @@ docs = [
     "mkdocstrings[python] ~=0.24",
     "mkdocs-awesome-pages-plugin ~=2.9",
 ]
-{%- elif documentation == "sphinx" -%}
+{% elif documentation == "sphinx" -%}
 docs = [
     "pydata_sphinx_theme ~=0.16",
     "myst-parser ~=4.0",

--- a/includes/pyproject/deps-pep-621.toml.jinja
+++ b/includes/pyproject/deps-pep-621.toml.jinja
@@ -1,0 +1,37 @@
+{% if documentation == "mkdocs" -%}
+docs = [
+    "mkdocs-material ~=9.5",
+    "mkdocstrings[python] ~=0.24",
+    "mkdocs-awesome-pages-plugin ~=2.9",
+]
+{%- elif documentation == "sphinx" -%}
+docs = [
+    "pydata_sphinx_theme ~=0.16",
+    "myst-parser ~=4.0",
+    "Sphinx ~=8.0",
+    "sphinx-autobuild ==2024.10.3"
+]
+{% endif %}
+{%- if use_test -%}
+tests = [
+    "pytest",
+    "pytest-cov",
+    "pytest-raises",
+    "pytest-randomly",
+    "pytest-xdist",
+]
+{% endif %}
+{%- if use_lint -%}
+style = [
+    "pydoclint",
+    "ruff",
+]
+{% endif %}
+{%- if use_types -%}
+types = [
+    "mypy",
+]
+{% endif -%}
+audit = [
+    "pip-audit",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ dependencies = [
     "pytest-xdist ~=3.6",
     "pre-commit",
     "ruamel.yaml>=0.18.0",
+    "validate-pyproject >=0.22",
+    "trove-classifiers>=2021.10.20",
+    "tomli >=2.0.2; python_version<'3.11'",
 ]
 
 [[tool.hatch.envs.test.matrix]]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -72,8 +72,18 @@ Download = "https://pypi.org/project/{{ project_slug }}/#files"
 dev = [
     "hatch",
     "pre-commit",
+    {%- if not use_hatch_envs %}
+    "{{ package_name }}[
+        {%- if documentation!="" %}docs,{% endif -%}
+        {%- if use_test %}tests,{% endif -%}
+        {%- if use_lint %}style,{% endif -%}
+        {%- if use_types %}types,{% endif -%}
+    audit]",
+    {%- endif %}
 ]
-
+{%- if not use_hatch_envs %}
+{% include pathjoin('includes', 'pyproject', 'deps-pep-621.toml.jinja') %}
+{%- endif %}
 ################################################################################
 # Tool Configuration
 ################################################################################

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -233,33 +233,20 @@ def test_dev_platform_gitlab(generated: Callable[..., Path]):
 
 
 def test_non_hatch_deps(
-    answers: dict[str, str],
     documentation: str,
-    tmp_path: Path,
+    generated: Callable[..., Path],
 ) -> None:
     """When we aren't using hatch, we should still get the optional dependencies."""
-    parent = tmp_path / answers["project_slug"]
-    parent.mkdir()
-
-    run_copy(
-        src_path=str(TEMPLATE),
-        dst_path=parent,
-        vcs_ref="HEAD",
-        data={
-            **answers,
-            "use_hatch_envs": False,
-            "use_lint": True,
-            "use_types": True,
-            "use_test": True,
-            "use_git": False,
-            "documentation": documentation,
-            "license": "MIT",
-        },
-        defaults=True,
+    project = generated(
+        use_hatch_envs=False,
+        use_lint=True,
+        use_types=True,
+        use_test=True,
+        use_git=False,
+        documentation=documentation,
     )
 
-
-    pyproject_file = parent / "pyproject.toml"
+    pyproject_file = project / "pyproject.toml"
     with pyproject_file.open("rb") as pfile:
         pyproject = tomllib.load(pfile)
 
@@ -272,7 +259,7 @@ def test_non_hatch_deps(
 
     # we don't want to hardcode all our deps here,
     # bc that would be a very fragile test indeed.
-    # Instead we just assume their presence and that the validity of the pyproject file
+    # Instead, we just assume their presence and that the validity of the pyproject file
     # means that they have been correctly specified.
     # except for the docs, where we want to test our switch works :)
     if documentation:

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -278,11 +278,3 @@ def test_non_hatch_deps(
     if documentation:
         assert "docs" in optional_deps
         assert any(dep.startswith(documentation) for dep in optional_deps["docs"])
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Currently if you say "no" to using hatch envs but "yes" to all the bells and whistles, you end up with a package that doesn't have the optional dependencies needed to use them :(

so this completes another leg of the combinatoric labyrinth we are constructing here ;)

for a project `my_package` with hatch off...

and nothing special is added:
```toml
[project.optional-dependencies]
dev = [
    "hatch",
    "pre-commit",
    "my_package[audit]",
]
audit = [
    "pip-audit",
]
```

and everything special is added

```toml
[project.optional-dependencies]
dev = [
    "hatch",
    "pre-commit",
    "my_package[docs,tests,style,types,audit]",
]
docs = [
    "pydata_sphinx_theme ~=0.16",
    "myst-parser ~=4.0",
    "Sphinx ~=8.0",
    "sphinx-autobuild ==2024.10.3"
]
tests = [
    "pytest",
    "pytest-cov",
    "pytest-raises",
    "pytest-randomly",
    "pytest-xdist",
]
style = [
    "pydoclint",
    "ruff",
]
types = [
    "mypy",
]
audit = [
    "pip-audit",
]
```

and the permutations in between.

I think this officially puts as at the time in every template's life where we need to start abstracting the values, because keeping deps synchronized will be tough.