### PR TITLE
Unitize/dedupe tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [
+    "docs: Tests relating to generated documentation!",
     "installs: Tests that install packages, e.g. from executing hatch env scripts",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "installs: Tests that install packages, e.g. from executing hatch env scripts",
+]
 
 [tool.ruff]
 line-length = 88

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -179,6 +179,7 @@ def test_template_suite(
         raise
 
 
+@pytest.mark.docs
 @pytest.mark.installs
 def test_docs_build(documentation: str, generated: Callable[..., Path]):
     """The docs should build."""
@@ -206,8 +207,27 @@ def test_dev_platform_github(generated: Callable[..., Path]):
     """Test github stuff idk!."""
     project = generated(use_git=True, dev_platform="GitHub")
 
+    workflows_dir =  project / '.github' / 'workflows'
+    assert workflows_dir.exists()
+    workflows = list(workflows_dir.iterdir())
+    assert len(workflows) > 0
+    assert all(workflow.suffix in ('.yml', '.yaml') for workflow in workflows)
+
     subprocess.run(
         "pre-commit run --all-files -v check-github-workflows",
+        cwd=project,
+        check=True,
+        shell=True,
+    )
+
+
+@pytest.mark.installs
+def test_dev_platform_gitlab(generated: Callable[..., Path]):
+    """Test gitlab stuff idk!."""
+    project = generated(use_git=True, dev_platform="GitLab")
+
+    subprocess.run(
+        "pre-commit run --all-files -v check-gitlab-ci",
         cwd=project,
         check=True,
         shell=True,

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -207,11 +207,11 @@ def test_dev_platform_github(generated: Callable[..., Path]):
     """Test github stuff idk!."""
     project = generated(use_git=True, dev_platform="GitHub")
 
-    workflows_dir =  project / '.github' / 'workflows'
+    workflows_dir =  project / ".github" / "workflows"
     assert workflows_dir.exists()
     workflows = list(workflows_dir.iterdir())
     assert len(workflows) > 0
-    assert all(workflow.suffix in ('.yml', '.yaml') for workflow in workflows)
+    assert all(workflow.suffix in (".yml", ".yaml") for workflow in workflows)
 
     subprocess.run(
         "pre-commit run --all-files -v check-github-workflows",

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Callable
 
 import pytest
 from copier import run_copy
@@ -58,15 +59,6 @@ def documentation(request: pytest.FixtureRequest) -> str:
     return request.param
 
 
-@pytest.fixture
-def destination_path(
-    tmp_path_factory: pytest.TempPathFactory,
-    dev_platform: str,
-) -> Path:
-    """Provide a destination directory based on the development platform."""
-    return tmp_path_factory.mktemp("instance") / dev_platform
-
-
 @pytest.fixture(scope="module")
 def answers() -> dict[str, str]:
     """Provide a full project context."""
@@ -84,26 +76,53 @@ def answers() -> dict[str, str]:
     }
 
 
+@pytest.fixture
+def generated(tmp_path: Path, answers: dict[str, str]) -> Callable[..., Path]:
+    """Fixture closure to generate a template project, overriding passed data values."""
+    def _generated(**kwargs) -> Path:
+        out_path = tmp_path
+        run_copy(
+            src_path=str(TEMPLATE),
+            dst_path=out_path,
+            vcs_ref="HEAD",
+            data={
+                **answers,
+                **kwargs,
+            },
+            defaults=True,
+        )
+
+        init_git(out_path)
+
+        return out_path
+    return _generated
+
+
+def init_git(path: Path):
+    """Initialize a git repository such that hatch-vcs can be used."""
+    project_dir = path.resolve(strict=True)
+    repo = Repo.init(project_dir)
+    repo.index.add(
+        [
+            Path(dirpath, name)
+            for dirpath, _, filenames in os.walk(project_dir)
+            for name in filenames
+        ],
+    )
+    repo.index.commit("chore: initialize template")
+
+
 def test_init_template(
-    destination_path: Path,
-    answers: dict[str, str],
     dev_platform: str,
     license: str,
     documentation: str,
+    generated: Callable[..., Path],
 ) -> None:
-    """Expect that the template can be initialized with any provided license."""
-    parent = destination_path / license / answers["project_slug"]
-    run_copy(
-        src_path=str(TEMPLATE),
-        dst_path=parent,
-        vcs_ref="HEAD",
-        data={
-            **answers,
-            "dev_platform": dev_platform,
-            "license": license,
-            "documentation": documentation,
-        },
-        defaults=True,
+    """Expect that the template can be initialized with all combinations of choices."""
+    parent = generated(
+        dev_platform=dev_platform,
+        license=license,
+        documentation=documentation,
     )
 
     project_files = {path.relative_to(parent) for path in parent.rglob("*")}
@@ -117,38 +136,12 @@ def test_init_template(
     assert expected.issubset(project_files), expected.difference(project_files)
 
 
+@pytest.mark.installs
 def test_template_suite(
-    destination_path: Path,
-    dev_platform: str,
-    answers: dict[str, str],
-    documentation: str,
+    generated: Callable[..., Path],
 ) -> None:
     """Expect that the test suite passes for the initialized template."""
-    parent = destination_path / answers["project_slug"]
-    run_copy(
-        src_path=str(TEMPLATE),
-        dst_path=parent,
-        vcs_ref="HEAD",
-        data={
-            **answers,
-            "dev_platform": dev_platform,
-            "license": "MIT",
-            "documentation": documentation,
-        },
-        defaults=True,
-    )
-
-    # Initialize a git repository such that hatch-vcs can be used.
-    project_dir = parent.resolve(strict=True)
-    repo = Repo.init(project_dir)
-    repo.index.add(
-        [
-            Path(dirpath, name)
-            for dirpath, _, filenames in os.walk(project_dir)
-            for name in filenames
-        ],
-    )
-    repo.index.commit("chore: initialize template")
+    project_dir = generated()
 
     # Run the local test suite.
     try:
@@ -164,13 +157,6 @@ def test_template_suite(
             check=True,
             shell=True,
         )
-        if documentation:
-            subprocess.run(
-                "hatch run docs:build",
-                cwd=project_dir,
-                check=True,
-                shell=True,
-            )
         subprocess.run(
             "hatch run style:check",
             cwd=project_dir,
@@ -183,19 +169,7 @@ def test_template_suite(
             check=True,
             shell=True,
         )
-        subprocess.run(
-            "pre-commit run --all-files -v check-readthedocs",
-            cwd=project_dir,
-            check=True,
-            shell=True,
-        )
-        if dev_platform.lower() == "github":
-            subprocess.run(
-                "pre-commit run --all-files -v check-github-workflows",
-                cwd=project_dir,
-                check=True,
-                shell=True,
-            )
+
     except subprocess.CalledProcessError as error:
         logger.error(  # noqa: TRY400
             "Command = %r; Return code = %d.",
@@ -203,3 +177,38 @@ def test_template_suite(
             error.returncode,
         )
         raise
+
+
+@pytest.mark.installs
+def test_docs_build(documentation: str, generated: Callable[..., Path]):
+    """The docs should build."""
+    if not documentation:
+        return
+
+    project = generated(documentation=documentation)
+
+    subprocess.run(
+        "hatch run docs:build",
+        cwd=project,
+        check=True,
+        shell=True,
+    )
+    subprocess.run(
+        "pre-commit run --all-files -v check-readthedocs",
+        cwd=project,
+        check=True,
+        shell=True,
+    )
+
+
+@pytest.mark.installs
+def test_dev_platform_github(generated: Callable[..., Path]):
+    """Test github stuff idk!."""
+    project = generated(use_git=True, dev_platform="GitHub")
+
+    subprocess.run(
+        "pre-commit run --all-files -v check-github-workflows",
+        cwd=project,
+        check=True,
+        shell=True,
+    )

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -80,10 +80,9 @@ def answers() -> dict[str, str]:
 def generated(tmp_path: Path, answers: dict[str, str]) -> Callable[..., Path]:
     """Fixture closure to generate a template project, overriding passed data values."""
     def _generated(**kwargs) -> Path:
-        out_path = tmp_path
         run_copy(
             src_path=str(TEMPLATE),
-            dst_path=out_path,
+            dst_path=tmp_path,
             vcs_ref="HEAD",
             data={
                 **answers,
@@ -92,9 +91,9 @@ def generated(tmp_path: Path, answers: dict[str, str]) -> Callable[..., Path]:
             defaults=True,
         )
 
-        init_git(out_path)
+        init_git(tmp_path)
 
-        return out_path
+        return tmp_path
     return _generated
 
 


### PR DESCRIPTION
Sorry for a bigger pr, these things are sorta all related and would be hard to do piecemeal

---

I was surprised at how long the tests took to run!

Here were all the tests with params that were running (sorta sorted because for some reason pytest was also running them out of order)

```
tests/test_template_init.py::test_init_template[GitHub-Apache-2.0-] PASSED        
tests/test_template_init.py::test_init_template[GitHub-Apache-2.0-sphinx] PASSED  
tests/test_template_init.py::test_init_template[GitHub-Apache-2.0-mkdocs] PASSED  
tests/test_template_init.py::test_init_template[GitHub-BSD-3-Clause-] PASSED      
tests/test_template_init.py::test_init_template[GitHub-BSD-3-Clause-sphinx] PASSED
tests/test_template_init.py::test_init_template[GitHub-BSD-3-Clause-mkdocs] PASSED
tests/test_template_init.py::test_init_template[GitHub-MIT-] PASSED               
tests/test_template_init.py::test_init_template[GitHub-MIT-mkdocs] PASSED         
tests/test_template_init.py::test_init_template[GitHub-MIT-sphinx] PASSED         
tests/test_template_init.py::test_init_template[GitLab-Apache-2.0-] PASSED        
tests/test_template_init.py::test_init_template[GitLab-Apache-2.0-sphinx] PASSED  
tests/test_template_init.py::test_init_template[GitLab-Apache-2.0-mkdocs] PASSED  
tests/test_template_init.py::test_init_template[GitLab-BSD-3-Clause-sphinx] PASSED
tests/test_template_init.py::test_init_template[GitLab-BSD-3-Clause-mkdocs] PASSED
tests/test_template_init.py::test_init_template[GitLab-BSD-3-Clause-] PASSED      
tests/test_template_init.py::test_init_template[GitLab-MIT-] PASSED               
tests/test_template_init.py::test_init_template[GitLab-MIT-mkdocs] PASSED         
tests/test_template_init.py::test_init_template[GitLab-MIT-sphinx] PASSED         

tests/test_template_init.py::test_template_suite[GitHub-] PASSED                  
tests/test_template_init.py::test_template_suite[GitHub-sphinx] PASSED          
tests/test_template_init.py::test_template_suite[GitHub-mkdocs] PASSED            
tests/test_template_init.py::test_template_suite[GitLab-] PASSED                  
tests/test_template_init.py::test_template_suite[GitLab-sphinx] PASSED            
tests/test_template_init.py::test_template_suite[GitLab-mkdocs] PASSED            
```

## Unit-izing

(is there a better word for "making a test more of a unit test?" i don't know a better one lol)

The `test_template_init` tests are fine, and that should be a combinatoric test because it's a) fast-ish, and b) a baseline test for "does this option work at all"

The `test_template_suite` tests were the thing that was taking a long time. For each of those parameterizations, every hatch env was being installed and each command was being run, but most of those tests don't vary by the parameterization. e.g. the `docs:build` script was being run twice for each docs framework even though nothing meaningfully varies in the docs by the git provider, as far as I can tell. This would become a problem p quickly if we were to add more git remotes (which i plan to in a sec) or different documentation modes (the mkdocs env is marked as "mkdocs-material" so i assume other skins/themes are a potential?)

Now don't get me wrong, i'm all in favor of *`~ rigorous testing ~`*, but i am also a believer in "tests that run fast are run more often," and also to the degree we can make our tests unit-ized and testing one small thing, we should. Both for maintenance's sake but also for developer experience's sake - e.g. i added a mark for tests that relate to `docs`, so if i changed something about how docs worked, i can just run all the tests that relate to docs quickly like `pytest -m docs` and so on. 

Now we can *add the parameterizations back* to the `test_template_suite` if we need to - y'all know the template better than I do and what is needed, i just got here - but by splitting off some pieces of it we get finer grained control over which and how tests are parameterized :). e.g. Ideally we would make a new test module for just running the scripts in a generated package, and each test function tests a single script over the parameterization that is relevant to that script, but didn't want to go that far yet!

## Independent-izing

~I see that we were using `tmp_dir_factory` and generating into subdirectories according to parameterizations? It looks like that was to re-use hatch envs, but i could be wrong. Problem with that is that now the tests are no longer independent! Copier doesn't clean the target directory by default, so files that are already there are left there. That's a problem e.g. for the `test_init` function, where we vary the destination directory by `dev_platform` and `license`, but not by `documentation`, and since that test just looks for the presence of files, if one of the `documentation` params broke something, we might not know!~ edit: forgot about the `numbered` param that autoincrements, whoop. nevermind this part!

So i swapped that out with just plain `tmp_path` which is a function-scoped fixture that makes a new dir for teach invocation of a test rather than `tmp_dir_factory` which is session-scoped.  If we want to have a custom output directory fixture function (which is totally valid and i actually do this in all my projects that generate output so that it's easier for people to submit samples of bugs by zipping up the tmp dir), i can add that back in, but i do think each test should be independent! this will also be necessary if we want to parallelize the tests :)

##  De-boilerplating

I noticed as i was splitting out the tests here that i was wanting to copy and paste the setup steps to run `copier`, which is a telltale sign it's time for a fixture or a helper :). So I made a helper function to init the generated project as a repo, and a fixture closure (because it uses the `answers` fixture for defaults) to generate a project with default args, except overriding with any kwargs that are passed. Together they make a tidy lil way to test variations on passed args. 

## Mark-ing

(ok marking is just a normal word it's just a pattern i can't help myself)

one last tiny thing, i also marked all the tests that install packages so that they could be excluded if needed - since this is a template generating package it's super normal and good to install packages and do network things during the tests, but it's also ncie to be able to turn that off since network-bound tests can be flaky and slow and use up disk space. that's just a convenience thing tho. atm most of the tests install packages, but i'm gonna be adding mostly non-network tests to like confirm our settings are correct as i go so it will make more sense later. Hopefully we only need a few end-to-end tests where we actually run the generated package and can mostly just validate the test output for correctness :)