### PR TITLE
cleanup tests after run

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,6 @@ def cleanup_hatch_envs(
         return
 
     hatch_dir = tmp_path_factory.mktemp("hatch")
-    hatch_dir.mkdir(exist_ok=True)
     monkeypatch_session.setenv("HATCH_DATA_DIR", str(hatch_dir))
 
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,9 +62,10 @@ def cleanup_hatch_envs(
     hatch_dir = tmp_path_factory.mktemp("hatch")
     monkeypatch_session.setenv("HATCH_DATA_DIR", str(hatch_dir))
 
-    yield
-
-    shutil.rmtree(hatch_dir, ignore_errors=True)
+    try:
+        yield
+    finally:
+        shutil.rmtree(hatch_dir, ignore_errors=True)
 
 # ---------------------------------------------
 # Fixtures - exports

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,17 @@
 """Ruff is forcing me to write a docstring for conftest.py."""
 
+import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING, Generator
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 from jinja2 import Environment, FileSystemLoader
 from ruamel.yaml import YAML
+
+if TYPE_CHECKING:
+    from _pytest.config.argparsing import Parser
+    from _pytest.tmpdir import TempPathFactory
 
 COPIER_CONFIG_PATH = Path(__file__).parents[1] / "copier.yml"
 INCLUDES_PATH = Path(__file__).parents[1] / "includes"
@@ -18,9 +25,59 @@ def _load_copier_config() -> dict:
 # don't mutate or else i'll have to get out the spray bottle (make it a fixture)
 COPIER_CONFIG = _load_copier_config()
 
+# --------------------------------------------------
+# pytest hooks
+# --------------------------------------------------
+
+def pytest_addoption(parser: "Parser") -> None:
+    """Add options to pytest."""
+    parser.addoption(
+        "--reuse-envs",
+        action="store_true",
+        help="After tests run, don't remove hatch environments created for "
+        "generated projects (not the test environments for the "
+        "pyos-package-template project itself).\n"
+        "otherwise, use a temporary directoy and remove it afterwards.",
+    )
+
+# --------------------------------------------------
+# Fixtures - autouse
+# --------------------------------------------------
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_hatch_envs(
+    pytestconfig: pytest.Config,
+    tmp_path_factory: "TempPathFactory",
+    monkeypatch_session: MonkeyPatch,
+) -> None:
+    """
+    Use a temporary directory for hatch envs & cleanup after session.
+
+    Unless --reuse-envs flag present.
+    """
+    if pytestconfig.getoption("--reuse-envs"):
+        yield
+        return
+
+    hatch_dir = tmp_path_factory.mktemp("hatch")
+    hatch_dir.mkdir(exist_ok=True)
+    monkeypatch_session.setenv("HATCH_DATA_DIR", str(hatch_dir))
+
+    yield
+
+    shutil.rmtree(hatch_dir, ignore_errors=True)
+
 # ---------------------------------------------
-# Fixtures
+# Fixtures - exports
 # ---------------------------------------------
+
+@pytest.fixture(scope="session")
+def monkeypatch_session() -> Generator[MonkeyPatch, None, None]:
+    """Monkeypatch you can use with a session scoped fixture."""
+    mpatch = MonkeyPatch()
+    yield mpatch
+    mpatch.undo()
+
 
 @pytest.fixture(scope="module")
 def includes() -> Environment:


### PR DESCRIPTION
I was wondering why i was running out of space on my laptop, turns out that the tests were creating a ton of hatch environments that were taking up 9GB, and it seemed like every run was creating new environments.

So this PR just temporarily sets the `HATCH_DATA_DIR` to a tmpdir and cleans it up after the test run. pytest removes temporary directories itself, but it keeps them around for a bit, and since they are big i just manually removed them.

I added a `--reuse-envs` flag like nox in case someone wanted to keep those around for some reason. Note that these are not the envs created to run the tests in, but the envs that are created when running the tests for the generated packages.