### PR TITLE
fix: pydoclint needs a dir path

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -164,7 +164,7 @@ known-first-party = ["src", "{{ package_name }}"]
 lines-after-imports = 1
 
 [tool.pydoclint]
-style = "google"  # TODO: Other styles are possible here, like 'numpy'
+style = "numpy"
 arg-type-hints-in-docstring = false
 check-return-types = false
 check-yield-types = false
@@ -208,7 +208,7 @@ dependencies = [
 detached = true
 
 [tool.hatch.envs.style.scripts]
-docstrings = "pydoclint"
+docstrings = "pydoclint src/"
 code = "ruff check {args}"
 format = "ruff format {args}"
 check = ["docstrings", "code"]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -208,7 +208,7 @@ dependencies = [
 detached = true
 
 [tool.hatch.envs.style.scripts]
-docstrings = "pydoclint src/"
+docstrings = "pydoclint src/ tests/"
 code = "ruff check {args}"
 format = "ruff format {args}"
 check = ["docstrings", "code"]


### PR DESCRIPTION
closes #75 
this just fixes a small bug and ensures we use numpy style docstrings which our packaging guide suggests.
NOTE, 