### PR TITLE
[DRAFT]: Add and configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "template/{% if use_git and dev_platform == 'GitHub' %}.github{% endif %}/workflows"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "dependencies: "
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/template/{% if use_git and dev_platform == 'GitHub' %}.github{% endif %}/dependabot.yml
+++ b/template/{% if use_git and dev_platform == 'GitHub' %}.github{% endif %}/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "dependencies: "
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
# Description

This pull request closes #78; it aims to add Dependabot to our repository for maintaining our workflows, and for downstream I have yet to test it out on my fork!

Here's a brief list of TODO items before we should be ready:

- [ ] Add documentation on how to use, configure, and maintain Dependabot
	- [ ] Add links to GitHub's documentation
	- [ ] Explain that Dependabot has to be enabled in the settings once they create a repository
	- [ ] Add a guide on what Dependabot does and how to handle incoming PRs for package updates
- [x] Ensure that Dependabot can update GitHub Actions dependencies in our repository's workflows
- [ ] Explore whether Dependabot can update GitHub Actions dependencies in the template's files