### PR TITLE
Restore tests, fix #88

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -104,7 +104,7 @@ use_lint:
   default: "{% if use_default != 'minimal' %}yes{% else %}no{% endif %}"
   help: "Do you want to lint your code and check file formatting?"
 
-use_pre-commit:
+use_precommit:
   when: "{{ use_default == 'no' }}"
   type: bool
   default: "{% if use_default != 'minimal' %}yes{% else %}no{% endif %}"

--- a/copier.yml
+++ b/copier.yml
@@ -40,7 +40,7 @@ documentation:
   choices:
     "Sphinx (https://pydata-sphinx-theme.readthedocs.io/en/stable/index.html)": sphinx
     "mkdocs-material (https://squidfunk.github.io/mkdocs-material)": mkdocs
-    No: "I don't need documentation for my project."
+    "No, I don't need documentation for my project.": "no"
   default: "sphinx"
 
 use_rtd:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,12 @@ dependencies = [
     "validate-pyproject >=0.22",
     "trove-classifiers>=2021.10.20",
     "tomli >=2.0.2; python_version<'3.11'",
+    "mkdocs-material ~=9.5",
+    "mkdocstrings[python] ~=0.24",
+    "mkdocs-awesome-pages-plugin ~=2.9",
+    "pydata_sphinx_theme ~=0.16",
+    "myst-parser ~=4.0",
+    "Sphinx ~=8.0",
 ]
 
 [[tool.hatch.envs.test.matrix]]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -12,9 +12,9 @@ requires = ["hatchling"{% if use_vcs_version %}, "hatch-vcs"{% endif %}]
 
 [project]
 name = "{{ package_name }}"
-{%- if use_vcs_version -%}
+{%- if use_vcs_version %}
 dynamic = ["version"]
-{% else %}
+{%- else %}
 version = "0.1.0"
 {%- endif %}
 {%- set wrapped_description = package_description | trim | wordwrap(width=88) %}

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -177,7 +177,11 @@ lines-after-imports = 1
 
 [tool.pydoclint]
 style = "numpy"
+{%- if use_types %}
+arg-type-hints-in-signature = true
+{%- else  %}
 arg-type-hints-in-signature = false
+{%- endif %}
 arg-type-hints-in-docstring = true
 check-return-types = false
 check-yield-types = false

--- a/template/src/{{ package_name }}/__init__.py.jinja
+++ b/template/src/{{ package_name }}/__init__.py.jinja
@@ -1,4 +1,8 @@
 {% include pathjoin("includes", "licenses", "header.txt.jinja") %}
 
-"""Add a docstring here for the init module. This might include a very
-brief description of the package, its purpose, and any important notes."""
+"""
+Add a docstring here for the init module.
+
+This might include a very brief description of the package,
+its purpose, and any important notes.
+"""

--- a/template/src/{{ package_name }}/example.py.jinja
+++ b/template/src/{{ package_name }}/example.py.jinja
@@ -1,26 +1,29 @@
 """
-A module that adds numbers together. You may want to delete this module or
-modify it for your package. It's generally good practice to have a docstring
+A module that adds numbers together.
+
+You may want to delete this module or modify it for your package.
+It's generally good practice to have a docstring
 that explains the purpose of the module, at the top.
 """
 
-def add_numbers(a, b):
+def add_numbers(a: float, b: float) -> float:
     """
     Add two numbers together and return the result.
+
     This is an example function with a numpy style docstring.
     We recommend using this style for consistency and readability.
 
     Parameters
     ----------
-    a : int or float
+    a : float
         The first number to add.
-    b : int or float
+    b : float
         The second number to add.
 
     Returns
     -------
-    int
+    float
         The sum of the two numbers.
-    """
 
+    """
     return a + b

--- a/template/src/{{ package_name }}/example.py.jinja
+++ b/template/src/{{ package_name }}/example.py.jinja
@@ -1,10 +1,12 @@
-"""A module that adds numbers together. You may want to delete this module or
+"""
+A module that adds numbers together. You may want to delete this module or
 modify it for your package. It's generally good practice to have a docstring
 that explains the purpose of the module, at the top.
 """
 
 def add_numbers(a, b):
-    """Add two numbers together and return the result.
+    """
+    Add two numbers together and return the result.
     This is an example function with a numpy style docstring.
     We recommend using this style for consistency and readability.
 
@@ -14,6 +16,7 @@ def add_numbers(a, b):
         The first number to add.
     b : int or float
         The second number to add.
+
     Returns
     -------
     int

--- a/template/{% if documentation == 'sphinx' %}docs{% endif %}/conf.py.jinja
+++ b/template/{% if documentation == 'sphinx' %}docs{% endif %}/conf.py.jinja
@@ -27,7 +27,10 @@ html_show_sphinx = False
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-version = importlib.metadata.version("{{ package_name }}")
+try:
+    version = importlib.metadata.version("{{ package_name }}")
+except importlib.metadata.PackageNotFoundError:
+    version = "0.0.0"
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "default"

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -72,6 +72,7 @@ def answers() -> dict[str, str]:
         "package_description": "Wubba Lubba Dub-Dub",
         "username": "rickprime",
         "year": str(today.year),
+        "use_default": "no",
     }
 
 
@@ -133,52 +134,49 @@ def test_init_template(
     }
     assert expected.issubset(project_files), expected.difference(project_files)
 
-# This test is breaking things because we assume that the user is using hatch
-# environments. however this is not always the case. So we will need to rewrite
-# this part of the test suite if we want to test environments to ensure that
-# the copier path selected actually uses hatch environments.
-# For the time being, i'm ensuring that we can build the project.
-# @pytest.mark.installs
-# def test_template_suite(
-#     generated: Callable[..., Path],
-# ) -> None:
-#     """Expect that the test suite passes for the initialized template."""
-#     project_dir = generated()
 
-#     # Run the local test suite.
-#     try:
-#         subprocess.run(
-#             "hatch build --clean",
-#             cwd=project_dir,
-#             check=True,
-#             shell=True,
-#         )
-        # subprocess.run(
-        #     f"hatch run +py={sys.version_info.major}.{sys.version_info.minor} test:run",
-        #     cwd=project_dir,
-        #     check=True,
-        #     shell=True,
-        # )
-        # subprocess.run(
-        #     "hatch run style:check",
-        #     cwd=project_dir,
-        #     check=True,
-        #     shell=True,
-        # )
-        # subprocess.run(
-        #     "hatch run audit:check",
-        #     cwd=project_dir,
-        #     check=True,
-        #     shell=True,
-        # )
+@pytest.mark.hatch
+@pytest.mark.installs
+def test_template_suite(
+    generated: Callable[..., Path],
+) -> None:
+    """Expect that the test suite passes for the initialized template."""
+    project_dir = generated()
 
-    # except subprocess.CalledProcessError as error:
-    #     logger.error(  # noqa: TRY400
-    #         "Command = %r; Return code = %d.",
-    #         error.cmd,
-    #         error.returncode,
-    #     )
-    #     raise
+    # Run the local test suite.
+    try:
+        subprocess.run(
+            "hatch build --clean",
+            cwd=project_dir,
+            check=True,
+            shell=True,
+        )
+        subprocess.run(
+            f"hatch run +py={sys.version_info.major}.{sys.version_info.minor} test:run",
+            cwd=project_dir,
+            check=True,
+            shell=True,
+        )
+        subprocess.run(
+            "hatch run style:check",
+            cwd=project_dir,
+            check=True,
+            shell=True,
+        )
+        subprocess.run(
+            "hatch run audit:check",
+            cwd=project_dir,
+            check=True,
+            shell=True,
+        )
+
+    except subprocess.CalledProcessError as error:
+        logger.error(  # noqa: TRY400
+            "Command = %r; Return code = %d.",
+            error.cmd,
+            error.returncode,
+        )
+        raise
 
 
 @pytest.mark.docs
@@ -190,51 +188,50 @@ def test_docs_build(documentation: str, generated: Callable[..., Path]):
 
     project = generated(documentation=documentation)
 
-    # Similar to other tests, we can't assume hatch is being used to run docs
-    # subprocess.run(
-    #     "hatch run docs:build",
-    #     cwd=project,
-    #     check=True,
-    #     shell=True,
-    # )
-    # subprocess.run(
-    #     "pre-commit run --all-files -v check-readthedocs",
-    #     cwd=project,
-    #     check=True,
-    #     shell=True,
-    # )
+    subprocess.run(
+        "hatch run docs:build",
+        cwd=project,
+        check=True,
+        shell=True,
+    )
+    subprocess.run(
+        "pre-commit run --all-files -v check-readthedocs",
+        cwd=project,
+        check=True,
+        shell=True,
+    )
 
 
-# @pytest.mark.installs
-# def test_dev_platform_github(generated: Callable[..., Path]):
-#     """Test github stuff idk!."""
-#     project = generated(use_git=True, dev_platform="GitHub")
+@pytest.mark.installs
+def test_dev_platform_github(generated: Callable[..., Path]):
+    """Test github stuff idk!."""
+    project = generated(use_git=True, dev_platform="GitHub")
 
-#     workflows_dir =  project / ".github" / "workflows"
-#     assert workflows_dir.exists()
-#     workflows = list(workflows_dir.iterdir())
-#     assert len(workflows) > 0
-#     assert all(workflow.suffix in (".yml", ".yaml") for workflow in workflows)
+    workflows_dir =  project / ".github" / "workflows"
+    assert workflows_dir.exists()
+    workflows = list(workflows_dir.iterdir())
+    assert len(workflows) > 0
+    assert all(workflow.suffix in (".yml", ".yaml") for workflow in workflows)
 
-#     subprocess.run(
-#         "pre-commit run --all-files -v check-github-workflows",
-#         cwd=project,
-#         check=True,
-#         shell=True,
-#     )
+    subprocess.run(
+        "pre-commit run --all-files -v check-github-workflows",
+        cwd=project,
+        check=True,
+        shell=True,
+    )
 
 
-# @pytest.mark.installs
-# def test_dev_platform_gitlab(generated: Callable[..., Path]):
-#     """Test gitlab stuff idk!."""
-#     project = generated(use_git=True, dev_platform="GitLab")
+@pytest.mark.installs
+def test_dev_platform_gitlab(generated: Callable[..., Path]):
+    """Test gitlab stuff idk!."""
+    project = generated(use_git=True, dev_platform="GitLab")
 
-#     subprocess.run(
-#         "pre-commit run --all-files -v check-gitlab-ci",
-#         cwd=project,
-#         check=True,
-#         shell=True,
-#     )
+    subprocess.run(
+        "pre-commit run --all-files -v check-gitlab-ci",
+        cwd=project,
+        check=True,
+        shell=True,
+    )
 
 
 def test_non_hatch_deps(

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -182,10 +182,14 @@ def test_docs_build(documentation: str, generated: Callable[..., Path], use_hatc
 
     if use_hatch_envs:
         run_command("hatch run docs:build", project)
-        run_command("pre-commit run --all-files -v check-readthedocs", project)
-    else:
-        pytest.skip("doing this in another commit...")
+    elif documentation == "mkdocs":
+        run_command("mkdocs build", project)
+    elif documentation == "sphinx":
+        run_command("sphinx-apidoc -o docs/api src/alien_clones", project)
+        # prepend pythonpath so we don't have to actually install here...
+        run_command(f"PYTHONPATH={str(project/'src')} sphinx-build -W -b html docs docs/_build", project)
 
+    run_command("pre-commit run --all-files -v check-readthedocs", project)
 
 @pytest.mark.installs
 def test_dev_platform_github(generated: Callable[..., Path]):

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -51,7 +51,7 @@ def dev_platform(request: pytest.FixtureRequest) -> str:
 
 @pytest.fixture(
     scope="module",
-    params=["mkdocs", "sphinx", "I don't need documentation for my project."],
+    params=["mkdocs", "sphinx", "no"],
 )
 def documentation(request: pytest.FixtureRequest) -> str:
     """Provide a documentation option."""
@@ -242,10 +242,6 @@ def test_non_hatch_deps(
     generated: Callable[..., Path],
 ) -> None:
     """When we aren't using hatch, we should still get the optional dependencies."""
-    # Skip if no documentation is selected as there won't be deps
-    if documentation == "I don't need documentation for my project.":
-        pytest.skip("No documentation selected.")
-
     project = generated(
         use_hatch_envs=False,
         use_lint=True,
@@ -271,6 +267,6 @@ def test_non_hatch_deps(
     # Instead, we just assume their presence and that the validity of the pyproject file
     # means that they have been correctly specified.
     # except for the docs, where we want to test our switch works :)
-    if documentation:
+    if documentation != "no":
         assert "docs" in optional_deps
         assert any(dep.startswith(documentation) for dep in optional_deps["docs"])

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -135,7 +135,6 @@ def test_init_template(
     assert expected.issubset(project_files), expected.difference(project_files)
 
 
-@pytest.mark.hatch
 @pytest.mark.installs
 def test_template_suite(
     generated: Callable[..., Path],


### PR DESCRIPTION
Fixes: #90 

OK so here's a good object lesson in "there are two ways to make the tests pass - fix the bugs, or make the tests more lenient" and why it's pretty much always a good idea to pick the former.

#88 made the global default, if nothing else was specified, to use the `minimal` build. the `minimal` build doesn't use hatch envs, and a number of the tests assumed that the default *would* use `hatch_envs` .

the only thing that needed to happen to fix that and restore the prior default behavior was to change the default args in the test fixtures like

https://github.com/sneakers-the-rat/pyos-package-template/blob/2db00c68479af64290c400bf19be0c1c4a1e8408/tests/test_template_init.py#L75

```python
@pytest.fixture(scope="module")
def answers() -> dict[str, str]:
    # ...
    return {
        # ...
        "use_default": "no",
    }
```

and after that, the tests revealed a number of problems with #88, tried to split these out to different commits

- https://github.com/pyOpenSci/pyos-package-template/commit/ceed92edec231e109b3b7cbc0572e9ba372572ce - the whitespace removal ended up breaking dynamic versions in non-minimal mode, rendering like

```toml

[project]
name = "{{ package_name }}"dynamic = ["version"]
```

so fixed that.

- https://github.com/pyOpenSci/pyos-package-template/commit/58e5c928f86aa3aa530e89130350b7eb49966e70 - the naming of the option `use_pre-commit` differed from the naming of the option in the template `use_precommit`, which caused that to always be `False`, so the pre commit config was never included. this also broke tests that did *not* assume hatch was present, like the option `use_hatch_envs=False` that i added before.
- https://github.com/pyOpenSci/pyos-package-template/commit/611817973d9b2f5750e24c7807e5c5fec985d7cc - the docs tests were failing because the new `example.py` file had invalid docstrings, each of the `Parameters` and `Returns` blocks need empty lines after them. I also added tests that mimic the hatch behavior for when `hatch_env = False` (so those deps needed to be added to the parent, test-runner hatch env), and that required adding a fallback version to `conf.py`
- https://github.com/pyOpenSci/pyos-package-template/commit/2db00c68479af64290c400bf19be0c1c4a1e8408 - the `example.py and `__init__.py` had further linter rule violations that needed to be corrected, so i updated those to match. i think it's probably a good idea that the example code we put in the template actually passes the tests and linting rules we include in the template.

---

other stuff:

- @lwasser was expressing not being sure about what the errors actually were, and so commented out the tests as a hail mary. only some of the test problems were from the default hatch assumption, others were just normal test failures. So i added another little helper function `run_command` that also displays `stdout` and `stderr` from errors in the subprocess calls.
- I'm not sure why one would ever want to guarantee that there *weren't* type annotations in the function signature, as `arg-type-hints-in-signature=false` does, i would think we would want that to always be `true` instead because type annotations are the best thing that has happened to python in a decade. however we definitely need that to be `true` when we have `use_types=True` because mypy will be like "wots all this then, no type hints??." IMO that should just be `true`, but i just made it conditional on `use_types` for now.
- The option for "no docs" in `documentation`  was changed from `""` to `"I don't need documentation for my project", so effectively that option was an enum like

```python
class Documentation(StrEnum):
    sphinx = "sphinx"
    mkdocs = "mkdocs"
    no = "I don't need documentation for my project"
```

which is a little odd. i assume that was on accident, so i inverted it so the "No, I don't need documentation for my project" was the thing that was shown to the user in the prompt, and the value was "no" like the rest of the copier config.
