### PR TITLE
Fix: add uv as default installer when using hatch

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -29,7 +29,6 @@ author_name:
   default: "{{ copyright_holder }}"
 
 author_email:
-  when: "{{ template_mode == 'custom' }}"
   type: str
   help: "The author's email address. Used in the package description."
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ lines-after-imports = 1
 
 [tool.hatch.envs.default]
 skip-install = true
+installer = "uv"
 
 [tool.hatch.envs.dev]
 description = """

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -103,6 +103,12 @@ version-file = "src/{{ package_name }}/_version.py"
 source = "vcs"
 {%- endif %}
 
+{%- if use_hatch_envs %}
+# Use UV to create Hatch environments
+[tool.hatch.envs.default]
+installer = "uv"
+{%- endif %}
+
 {%- if use_test %}
 
 ######## Configure pytest for your test suite ########


### PR DESCRIPTION
closes #113 

This ensures the minimal version sees "email" and also adds uv as a default installer. 