### PR TITLE
Remove readthedocs.io url from pyproject toml for minimal version

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -60,7 +60,9 @@ Homepage = "{{ dev_platform_url }}/{{ username }}/{{ project_slug }}"
 "Source Code" = "{{ dev_platform_url }}/{{ username }}/{{ project_slug }}"
 "Bug Tracker" = "{{ dev_platform_url }}/{{ username }}/{{ project_slug }}/issues"
 {%- endif %}
+{%- if use_rtd %}
 Documentation = "https://{{ project_slug }}.readthedocs.io"
+{%- endif %}
 Download = "https://pypi.org/project/{{ project_slug }}/#files"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Removed the readthedocs.io url by editing `pyproject.toml.jinja` to use the boolean flag `use_rtd`.